### PR TITLE
Specify Debugger.authorize docs

### DIFF
--- a/lib/debugger/debugger.lua
+++ b/lib/debugger/debugger.lua
@@ -67,7 +67,7 @@ Debugger.__index = Debugger
 	@within Debugger
 
 	Create this property in Debugger to specify a function that will be called to determine if a player should be
-	allowed to connect to the server-side debugger.
+	allowed to connect to the server-side debugger. In Studio, this property is ignored.
 
 	If not specified, the default behavior is to allow anyone in Studio and disallow everyone in a live game.
 


### PR DESCRIPTION
The documentation currently indicates that `Debugger.authorize` will be evaluated in Studio, but it is not. This PR adds specification to indicate that the property is ignored in Studio.
