### PR TITLE
Add reverse world

### DIFF
--- a/lib/World.lua
+++ b/lib/World.lua
@@ -21,8 +21,9 @@ World.__index = World
 
 --[=[
 	Creates a new World.
+	@param isReversed boolean? -- If True, the entity ID will start decreasing from -1.
 ]=]
-function World.new()
+function World.new(isReversed: boolean?)
 	local firstStorage = {}
 
 	return setmetatable({
@@ -45,9 +46,12 @@ function World.new()
 		-- when to update the queryCache.
 		_entityArchetypeCache = {},
 
+		-- If True, the entity ID will start decreasing from -1.
+		_isReversed = isReversed,
+		
 		-- The next ID that will be assigned with World:spawn
-		_nextId = 1,
-
+		_nextId = isReversed and -1 or 1,
+		
 		-- The total number of active entities in the world
 		_size = 0,
 
@@ -152,8 +156,14 @@ function World:spawnAt(id, ...)
 
 	self._size += 1
 
-	if id >= self._nextId then
-		self._nextId = id + 1
+	if self._isReversed then
+		if id <= self._nextId then
+			self._nextId = id - 1
+		end
+	else
+		if id >= self._nextId then
+			self._nextId = id + 1
+		end
 	end
 
 	local components = {}

--- a/lib/World.spec.lua
+++ b/lib/World.spec.lua
@@ -110,6 +110,40 @@ return function()
 			expect(nextId).to.equal(6)
 		end)
 
+		it("should allow spawning entities in opposite region, default world", function()
+			local world = World.new()
+
+			local A = component()
+			local id = world:spawnAt(-5, A())
+
+			expect(function()
+				world:spawnAt(-5, A())
+			end).to.throw()
+
+			expect(id).to.equal(-5)
+
+			local nextId = world:spawn(A())
+			expect(nextId).to.equal(1)
+		end)
+
+		it("should allow spawning entities in opposite region, reversed world", function()
+			local world = World.new(true)
+
+			local A = component()
+			local id = world:spawnAt(5, A())
+
+			expect(function()
+				world:spawnAt(5, A())
+			end).to.throw()
+
+			expect(id).to.equal(5)
+
+			local nextId = world:spawn(A())
+			expect(nextId).to.equal(-1)
+			nextId = world:spawn(A())
+			expect(nextId).to.equal(-2)
+		end)
+
 		it("should allow inserting and removing components from existing entities", function()
 			local world = World.new()
 


### PR DESCRIPTION
## Proposed changes

Added Reverse World Feature: Entities added using the world:spawn() function will now receive negative numbers as their IDs.


## Additional comments


During the development and usage of the ECS (Entity Component System) on the client-side, I encountered challenges in distinguishing whether an entity was created locally on the client or synchronized from the server. This ambiguity can lead to confusion and potential bugs in the system's behavior, especially in environments where client-server synchronization is critical.

To address this issue, I propose introducing a feature that utilizes opposite ID allocation strategies for the client and server worlds. By assigning negative IDs to entities spawned on the client and reserving positive IDs for server-spawned entities (or vice versa), we can easily identify the origin of any given entity based on its ID. This change simplifies the logic needed to differentiate between client-created and server-synchronized entities, improving the robustness and maintainability of the system.
