### PR TITLE
Fix debugger state view

### DIFF
--- a/lib/debugger/widgets/link.lua
+++ b/lib/debugger/widgets/link.lua
@@ -16,7 +16,6 @@ return function(Plasma)
 			local button = create("TextButton", {
 				[ref] = "button",
 				BackgroundTransparency = 1,
-				AutomaticSize = Enum.AutomaticSize.XY,
 				Text = "",
 
 				create("UIPadding", {


### PR DESCRIPTION
An AutomaticSize got sneaked in there when I made the debugger style changes, breaking it. Surprised nobody noticed this!

Before:
![image](https://github.com/matter-ecs/matter/assets/44332148/cb9043e1-6bdd-4d19-895f-e4294b291821)

After:
![image](https://github.com/matter-ecs/matter/assets/44332148/2bbb085f-575a-4e75-99cc-5c912461b477)
