### PR TITLE
Loop parameter names

### DIFF
--- a/lib/debugger/debugger.lua
+++ b/lib/debugger/debugger.lua
@@ -116,6 +116,20 @@ Debugger.__index = Debugger
 ]=]
 
 --[=[
+  @prop loopParameterNames {string}
+	@within Debugger
+
+	Create this property in Debugger to specify the names of the parameters to your Loop constructor. This is used to
+	display a more accurate name in the debugger.
+
+	If not specified, the default behavior is to label Worlds as "World" and tables as "table", followed by its index.
+
+	```lua
+	debugger.loopParameterNames = {"World", "State", "Widgets"}
+  ```
+]=]
+
+--[=[
 	Creates a new Debugger.
 
 	You need to depend on [Plasma](https://eryn.io/plasma/) in your project and pass a handle to it here.
@@ -149,6 +163,7 @@ function Debugger.new(plasma)
 	local self = setmetatable({
 		plasma = plasma,
 		loop = nil,
+		loopParameterNames = {},
 		enabled = false,
 		componentRefreshFrequency = 3,
 		_windowCount = 0,

--- a/lib/debugger/debugger.lua
+++ b/lib/debugger/debugger.lua
@@ -116,7 +116,7 @@ Debugger.__index = Debugger
 ]=]
 
 --[=[
-  @prop loopParameterNames {string}
+	@prop loopParameterNames {string}
 	@within Debugger
 
 	Create this property in Debugger to specify the names of the parameters to your Loop constructor. This is used to
@@ -126,7 +126,7 @@ Debugger.__index = Debugger
 
 	```lua
 	debugger.loopParameterNames = {"World", "State", "Widgets"}
-  ```
+	```
 ]=]
 
 --[=[

--- a/lib/debugger/ui.lua
+++ b/lib/debugger/ui.lua
@@ -82,8 +82,11 @@ local function ui(debugger, loop)
 				local selected = (#objectStack > 0 and object == objectStack[#objectStack].value)
 					or (debugger.debugWorld == object and worldViewOpen)
 
+				local name = debugger.loopParameterNames[index]
+				local defaultName = (if isWorld then "World" else "table") .. " " .. index
+
 				table.insert(items, {
-					text = (if isWorld then "World" else "table") .. " " .. index,
+					text = if name then name else defaultName,
 					icon = if isWorld then "🌐" else "{}",
 					object = object,
 					selected = selected,


### PR DESCRIPTION
Adds an extra field to the Debugger called `loopParameterNames` to specify the names you want displayed in the Matter debugger, rather than the default `World 1`, `table 2`, `table 3`, etc.

See https://github.com/evaera/matter/pull/65 for further discussion.