### PR TITLE
Revert format table to working state

### DIFF
--- a/lib/debugger/formatTable.lua
+++ b/lib/debugger/formatTable.lua
@@ -29,7 +29,6 @@ local function formatTable(object, mode, _padLength, _depth)
 	end)
 
 	local count = 0
-	local size = #values
 	for _, entry in values do
 		local key = entry.key
 		local value = entry.value
@@ -41,8 +40,7 @@ local function formatTable(object, mode, _padLength, _depth)
 		end
 
 		if mode == FormatMode.Long then
-			local spaces = string.rep("  ", _depth - 1)
-			part ..= if count == 0 then spaces else "\n" .. spaces
+			part ..= "\n" .. string.rep("  ", _depth - 1)
 		end
 
 		count += 1
@@ -96,8 +94,7 @@ local function formatTable(object, mode, _padLength, _depth)
 	end
 
 	if mode == FormatMode.Long then
-		local spaces = string.rep("  ", _depth - 1)
-		str ..= if count == size then spaces else "\n" .. spaces
+		str ..= "\n" .. string.rep("  ", _depth - 2)
 	end
 
 	if mode == FormatMode.Short or _depth > 1 then


### PR DESCRIPTION
My commit to make the debugger more compact resulted in a regression messing up formatting tables (like in the component view or hover inspect).

This PR reverts it to the old behavior, which makes it actually readable now.

However, the old issue with this formatting still stands: there are newlines at the beginning and end of each table on the top level. This needs to be fixed in a different PR. I will make an issue after this is merged.