### PR TITLE
Support calling noopQuery

### DIFF
--- a/lib/World.lua
+++ b/lib/World.lua
@@ -389,6 +389,7 @@ local noopQuery = setmetatable({
 	__iter = function()
 		return noop
 	end,
+	__call = noop,
 })
 
 --[=[


### PR DESCRIPTION
## Proposed changes

This PR only adds the `__call` method to noopQuery, which prevents an error that could happen when attempting to query components that haven't been used yet.

## Related issues

I could not spot any reported issues that related to this.
