### PR TITLE
Fix empty view return type

### DIFF
--- a/lib/World.luau
+++ b/lib/World.luau
@@ -381,10 +381,14 @@ local noopQuery = setmetatable({
 	without = function(self)
 		return self
 	end,
-	view = {
-		get = noop,
-		contains = noop,
-	},
+	view = function()
+		return {
+			get = noop,
+			contains = function()
+				return false
+			end,
+		}
+	end,
 }, {
 	__iter = function()
 		return noop

--- a/lib/World.spec.luau
+++ b/lib/World.spec.luau
@@ -224,6 +224,21 @@ return function()
 			expect(withoutCount).to.equal(1)
 		end)
 
+		it("should return an empty query with the same methods", function()
+			local world = World.new()
+
+			local Player = component()
+			local Enemy = component()
+
+			expect(world:query(Player):next()).to.equal(nil)
+			expect(#world:query(Player):snapshot()).to.equal(0)
+
+			expect(world:query(Player):without(Enemy):next()).to.equal(world:query(Player):next())
+
+			expect(world:query(Player):view():get()).to.equal(nil)
+			expect(world:query(Player):view():contains()).to.equal(false)
+		end)
+
 		it("should allow getting single components", function()
 			local world = World.new()
 


### PR DESCRIPTION
This PR fixes the return type for a view on an empty query. I also added a test to try and keep the noop query similar to a regular query.