### PR TITLE
Alt-Hover Inspection Improvements

### DIFF
--- a/lib/debugger/widgets/hoverInspect.luau
+++ b/lib/debugger/widgets/hoverInspect.luau
@@ -12,7 +12,7 @@ return function(plasma)
 			str ..= tostring(component) .. " "
 
 			if next(componentData) == nil then
-				str ..= "{ }"
+				str ..= "{ }\n"
 			else
 				str ..= (formatTable(componentData, FormatMode.Long, 0, 2) .. "\n")
 			end

--- a/lib/debugger/widgets/hoverInspect.luau
+++ b/lib/debugger/widgets/hoverInspect.luau
@@ -6,7 +6,7 @@ return function(plasma)
 	return plasma.widget(function(world, id, custom)
 		local entityData = world:_getEntity(id)
 
-		local str = "Entity " .. id .. "\n\n"
+		local str = "<b>Entity " .. id .. "</b>\n\n"
 
 		for component, componentData in pairs(entityData) do
 			str ..= tostring(component) .. " "

--- a/lib/debugger/widgets/tooltip.luau
+++ b/lib/debugger/widgets/tooltip.luau
@@ -11,6 +11,7 @@ return function(plasma)
 				TextXAlignment = Enum.TextXAlignment.Left,
 				TextYAlignment = Enum.TextYAlignment.Top,
 				TextSize = 13,
+				RichText = true,
 				BorderSizePixel = 0,
 				Font = Enum.Font.Code,
 				TextStrokeTransparency = 0.5,

--- a/lib/debugger/widgets/tooltip.luau
+++ b/lib/debugger/widgets/tooltip.luau
@@ -16,7 +16,7 @@ return function(plasma)
 				Font = Enum.Font.Code,
 				TextStrokeTransparency = 0.5,
 				TextColor3 = Color3.new(1, 1, 1),
-				BackgroundTransparency = 0.5,
+				BackgroundTransparency = 0.2,
 				BackgroundColor3 = style.bg1,
 				AutomaticSize = Enum.AutomaticSize.XY,
 

--- a/lib/debugger/widgets/tooltip.luau
+++ b/lib/debugger/widgets/tooltip.luau
@@ -10,7 +10,7 @@ return function(plasma)
 				[ref] = "label",
 				TextXAlignment = Enum.TextXAlignment.Left,
 				TextYAlignment = Enum.TextYAlignment.Top,
-				TextSize = 15,
+				TextSize = 13,
 				BorderSizePixel = 0,
 				Font = Enum.Font.Code,
 				TextStrokeTransparency = 0.5,


### PR DESCRIPTION
## Proposed changes
The `Alt` hover inspection tooltip does not currently add a new line to the end of an empty component table when building the tooltip string. This results in a cramped inspection tooltip when trying to look at an entity's components on the fly. This PR aims to fix this by adding a `\n` after the empty component string.

Furthermore, I have made additional adjustments to the alt hover tooltip, which include:
- Reduced Text Size (since this fix will result in slightly taller tooltips)
- More Opaque Background (0.5 to 0.2)
- `RichText` enabled for **Entity ID** to be bold in the tooltip string

## Preview
### Old:
![image](https://github.com/user-attachments/assets/87c3a096-2de8-4bb8-b6ad-10f977abdd33)

### New:
![image](https://github.com/user-attachments/assets/e4ad633a-aab2-4271-ab29-6803fae3d4a3)
As shown above, the tooltip is now adding a new line after each component as expected and has a slightly improved aesthetic versus the old one.
