### PR TITLE
Fix debugger entity inspect newlines

### DIFF
--- a/lib/debugger/formatTable.luau
+++ b/lib/debugger/formatTable.luau
@@ -39,7 +39,7 @@ local function formatTable(object, mode, _padLength, _depth)
 			part ..= ", "
 		end
 
-		if mode == FormatMode.Long then
+		if mode == FormatMode.Long and (if count == 0 then _depth > 1 else true) then
 			part ..= "\n" .. string.rep("  ", _depth - 1)
 		end
 
@@ -93,7 +93,7 @@ local function formatTable(object, mode, _padLength, _depth)
 		end
 	end
 
-	if mode == FormatMode.Long then
+	if mode == FormatMode.Long and _depth > 1 and #values > 0 then
 		str ..= "\n" .. string.rep("  ", _depth - 2)
 	end
 


### PR DESCRIPTION
## Proposed changes
At the moment the debugger view (specifically the entity inspector panel) adds a new-line both above and below the component data string thus taking up more vertical space in the components table. This change fixes that such that the table view is properly condensed by preventing unecessary newline characters being added to the component data strings (via `formatTable`)

## Related issues
Fixes #70
Thanks @jackTabsCode for referring me to work on this issue, I'm glad the entity inspection panel will be a little more compact for us all now. 😄 

## Additional comments
Admittedly, the code changes for this are fairly ambiguous given that the `tableFormatter` is not as readable as it could be. The nature of this fix was to:
- Check that the `_depth` value was more than 1 before attempting to add a `\n` character before the first table item. This `_depth` value (when it is of a value of `1`) causes no curly braces to be displayed for the top level table (intended behaviour for the debugger view). However, this means that the piece of code that handled adding `\n` after each table item would _**also**_ run when the `_depth` was at `1` which is why the debugger has always had extra space above and below table items.

- Empty tables do not get carried down to a new line now, they remain on the same line. This further helps condense the entity inspector table.
  
## Preview
## 🔴 Before: 
![image](https://github.com/user-attachments/assets/455dafed-94e4-4ed6-ad02-f8ae0be078ff)

## 🟢 After: 
![image](https://github.com/user-attachments/assets/335dbfe4-b115-44bd-a536-6f1aa969e316)
![image](https://github.com/user-attachments/assets/b68ded37-8d46-46c3-8e67-8009fb99cdae)

