### PR TITLE
World method refinements

### DIFF
--- a/lib/World.luau
+++ b/lib/World.luau
@@ -4,7 +4,7 @@ local topoRuntime = require(script.Parent.topoRuntime)
 
 local assertValidComponentInstance = Component.assertValidComponentInstance
 local assertValidComponent = Component.assertValidComponent
-local assertComponentsProvided = Component.assertComponentsProvided
+local assertComponentsArgsProvided = Component.assertComponentsArgsProvided
 local archetypeOf = archetypeModule.archetypeOf
 local negateArchetypeOf = archetypeModule.negateArchetypeOf
 local areArchetypesCompatible = archetypeModule.areArchetypesCompatible
@@ -15,7 +15,7 @@ end
 
 local function assertWorldOperationIsValid(world, id: number, ...)
 	assertEntityExists(world, id)
-	assertComponentsProvided(...)
+	assertComponentsArgsProvided(...)
 end
 
 --[=[

--- a/lib/World.luau
+++ b/lib/World.luau
@@ -9,7 +9,14 @@ local archetypeOf = archetypeModule.archetypeOf
 local negateArchetypeOf = archetypeModule.negateArchetypeOf
 local areArchetypesCompatible = archetypeModule.areArchetypesCompatible
 
-local ERROR_NO_ENTITY = "Entity doesn't exist, use world:contains to check if needed"
+local function assertEntityExists(world, id: number)
+	assert(world:contains(id), "Entity doesn't exist, use world:contains to check if needed")
+end
+
+local function assertWorldOperationIsValid(world, id: number, ...)
+	assertEntityExists(world, id)
+	assertComponentsProvided(...)
+end
 
 --[=[
 	@class World
@@ -260,11 +267,7 @@ end
 	@param ... ComponentInstance -- The component values to spawn the entity with.
 ]=]
 function World:replace(id, ...)
-	assertComponentsProvided(...)
-
-	if not self:contains(id) then
-		error(ERROR_NO_ENTITY, 2)
-	end
+	assertWorldOperationIsValid(self, id, ...)
 
 	local components = {}
 	local metatables = {}
@@ -351,11 +354,7 @@ end
 	@return ... -- Returns the component values in the same order they were passed in
 ]=]
 function World:get(id, ...)
-	assertComponentsProvided(...)
-
-	if not self:contains(id) then
-		error(ERROR_NO_ENTITY, 2)
-	end
+	assertWorldOperationIsValid(self, id, ...)
 
 	local entity = self:_getEntity(id)
 
@@ -1012,11 +1011,7 @@ end
 function World:insert(id, ...)
 	debug.profilebegin("insert")
 
-	assertComponentsProvided(...)
-
-	if not self:contains(id) then
-		error(ERROR_NO_ENTITY, 2)
-	end
+	assertWorldOperationIsValid(self, id, ...)
 
 	local entity = self:_getEntity(id)
 
@@ -1060,11 +1055,7 @@ end
 	@return ...ComponentInstance -- Returns the component instance values that were removed in the order they were passed.
 ]=]
 function World:remove(id, ...)
-	assertComponentsProvided(...)
-
-	if not self:contains(id) then
-		error(ERROR_NO_ENTITY, 2)
-	end
+	assertWorldOperationIsValid(self, id, ...)
 
 	local entity = self:_getEntity(id)
 

--- a/lib/World.luau
+++ b/lib/World.luau
@@ -4,7 +4,7 @@ local topoRuntime = require(script.Parent.topoRuntime)
 
 local assertValidComponentInstance = Component.assertValidComponentInstance
 local assertValidComponent = Component.assertValidComponent
-local assertComponentsArgsProvided = Component.assertComponentsArgsProvided
+local assertComponentArgsProvided = Component.assertComponentArgsProvided
 local archetypeOf = archetypeModule.archetypeOf
 local negateArchetypeOf = archetypeModule.negateArchetypeOf
 local areArchetypesCompatible = archetypeModule.areArchetypesCompatible
@@ -15,7 +15,7 @@ end
 
 local function assertWorldOperationIsValid(world, id: number, ...)
 	assertEntityExists(world, id)
-	assertComponentsArgsProvided(...)
+	assertComponentArgsProvided(...)
 end
 
 --[=[

--- a/lib/World.spec.luau
+++ b/lib/World.spec.luau
@@ -580,6 +580,22 @@ return function()
 			end).to.throw()
 		end)
 
+		it("should error when entity does not exist (get, insert, replace, remove)", function()
+			expect(function()
+				local world = World.new()
+
+				world:get(2000)
+				world:insert(2000)
+				world:replace(2000)
+				world:remove(2000)
+
+				world:get()
+				world:insert()
+				world:replace()
+				world:remove()
+			end).to.throw()
+		end)
+
 		it("should allow snapshotting a query", function()
 			local world = World.new()
 

--- a/lib/component.luau
+++ b/lib/component.luau
@@ -161,7 +161,7 @@ end
 
 local function assertComponentsProvided(...)
 	if not (...) then
-		error(`No components passed to world:{debug.info(2, "n")}, at least one component is required`, 2)
+		error(`No components passed to world:{debug.info(3, "n")}, at least one component is required`, 2)
 	end
 end
 

--- a/lib/component.luau
+++ b/lib/component.luau
@@ -159,7 +159,7 @@ local function assertValidComponentInstance(value, position)
 	end
 end
 
-local function assertComponentsArgsProvided(...)
+local function assertComponentArgsProvided(...)
 	if not (...) then
 		error(`No components passed to world:{debug.info(3, "n")}, at least one component is required`, 2)
 	end
@@ -169,5 +169,5 @@ return {
 	newComponent = newComponent,
 	assertValidComponentInstance = assertValidComponentInstance,
 	assertValidComponent = assertValidComponent,
-	assertComponentsArgsProvided = assertComponentsArgsProvided,
+	assertComponentArgsProvided = assertComponentArgsProvided,
 }

--- a/lib/component.luau
+++ b/lib/component.luau
@@ -159,7 +159,7 @@ local function assertValidComponentInstance(value, position)
 	end
 end
 
-local function assertComponentsProvided(...)
+local function assertComponentsArgsProvided(...)
 	if not (...) then
 		error(`No components passed to world:{debug.info(3, "n")}, at least one component is required`, 2)
 	end
@@ -169,5 +169,5 @@ return {
 	newComponent = newComponent,
 	assertValidComponentInstance = assertValidComponentInstance,
 	assertValidComponent = assertValidComponent,
-	assertComponentsProvided = assertComponentsProvided,
+	assertComponentsArgsProvided = assertComponentsArgsProvided,
 }


### PR DESCRIPTION
## Proposed changes
This change aimed to tidy up some of the assertions in the `World` class and ensure that assertions for the entity existing are deduplicated into a shared function between various methods.

Also renamed `assertComponentsProvided` to `assertComponentArgsProvided` as this is more accurate (since components passed can be component metatables or actual component instances depending on the method)

## Assertion Changes
![image](https://github.com/user-attachments/assets/d633000e-af96-4048-8403-783fab1d718b)
![image](https://github.com/user-attachments/assets/7f67e5ad-68a1-4aab-8c7b-446c46514831)
