### PR TITLE
Mitigate error in `hoverInspect` when entity no longer exists

### DIFF
--- a/lib/debugger/ui.luau
+++ b/lib/debugger/ui.luau
@@ -41,7 +41,7 @@ local function ui(debugger, loop)
 	local objectStack = plasma.useState({})
 	local worldViewOpen, setWorldViewOpen = plasma.useState(false)
 
-	if debugger.hoverEntity then
+	if debugger.hoverEntity and debugger.debugWorld:contains(debugger.hoverEntity) then
 		custom.hoverInspect(debugger.debugWorld, debugger.hoverEntity, custom)
 	end
 

--- a/lib/debugger/ui.luau
+++ b/lib/debugger/ui.luau
@@ -40,9 +40,12 @@ local function ui(debugger, loop)
 
 	local objectStack = plasma.useState({})
 	local worldViewOpen, setWorldViewOpen = plasma.useState(false)
+	local worldExists = debugger.debugWorld ~= nil
 
-	if debugger.hoverEntity and debugger.debugWorld:contains(debugger.hoverEntity) then
-		custom.hoverInspect(debugger.debugWorld, debugger.hoverEntity, custom)
+	if debugger.hoverEntity and worldExists then
+		if debugger.debugWorld:contains(debugger.hoverEntity) then
+			custom.hoverInspect(debugger.debugWorld, debugger.hoverEntity, custom)
+		end
 	end
 
 	custom.container(function()

--- a/lib/debugger/widgets/hoverInspect.luau
+++ b/lib/debugger/widgets/hoverInspect.luau
@@ -4,6 +4,10 @@ local FormatMode = formatTableModule.FormatMode
 
 return function(plasma)
 	return plasma.widget(function(world, id, custom)
+		if not world:contains(id) then
+			return
+		end
+
 		local entityData = world:_getEntity(id)
 
 		local str = "<b>Entity " .. id .. "</b>\n\n"

--- a/lib/debugger/widgets/hoverInspect.luau
+++ b/lib/debugger/widgets/hoverInspect.luau
@@ -4,10 +4,6 @@ local FormatMode = formatTableModule.FormatMode
 
 return function(plasma)
 	return plasma.widget(function(world, id, custom)
-		if not world:contains(id) then
-			return
-		end
-
 		local entityData = world:_getEntity(id)
 
 		local str = "<b>Entity " .. id .. "</b>\n\n"


### PR DESCRIPTION
## Proposed changes
Add a check at the top of the `hoverInspect` plasma component to see if the world contains the entity `id` before trying to call `_getEntity`.

## Related issues
Fixes #16.
