### PR TITLE
Syntax Highlight Fix - Remove `$` from template literal

### DIFF
--- a/lib/debugger/formatTable.luau
+++ b/lib/debugger/formatTable.luau
@@ -7,7 +7,7 @@ function colorize(value, color)
 		value = string.format("%.1f", value)
 	end
 
-	return `<font color="${color}">{value}</font>`
+	return `<font color="{color}">{value}</font>`
 end
 
 function colorizeMany(color, ...)


### PR DESCRIPTION
## Proposed changes
Remove `$` in template literal to fix syntax highlighting.