### PR TITLE
Implement world inspect table sorting (by count and component name a-z)

### DIFF
--- a/lib/debugger/widgets/worldInspect.luau
+++ b/lib/debugger/widgets/worldInspect.luau
@@ -1,6 +1,9 @@
 local formatTableModule = require(script.Parent.Parent.formatTable)
 local formatTable = formatTableModule.formatTable
 
+local BY_COMPONENT_NAME = "ComponentName"
+local BY_ENTITY_COUNT = "EntityCount"
+
 return function(plasma)
 	return plasma.widget(function(debugger, objectStack)
 		local style = plasma.useStyle()
@@ -8,8 +11,10 @@ return function(plasma)
 		local world = debugger.debugWorld
 
 		local cache, setCache = plasma.useState()
-		-- TODO #97 Implement sorting by descending as well.
-		local ascendingOrder, _ = plasma.useState(false)
+
+		local sortType, setSortType = plasma.useState(BY_COMPONENT_NAME)
+		local isAscendingOrder, setIsAscendingOrder = plasma.useState(true)
+
 		local skipIntersections, setSkipIntersections = plasma.useState(true)
 		local debugComponent, setDebugComponent = plasma.useState()
 
@@ -71,26 +76,47 @@ return function(plasma)
 					})
 				end
 
+				local indexForSort = if sortType == BY_ENTITY_COUNT then 1 else 2
+
 				table.sort(items, function(a, b)
-					if ascendingOrder then
-						return a[1] < b[1]
+					if isAscendingOrder then
+						return a[indexForSort] < b[indexForSort]
 					end
 
-					-- Default to alphabetical
-					return a[2] < b[2]
+					return a[indexForSort] > b[indexForSort]
 				end)
 
-				table.insert(items, 1, { "Count", "Component" })
+				local arrow = if isAscendingOrder then "▲" else "▼"
+				local countHeading = `{if sortType == BY_ENTITY_COUNT then arrow else ""} Count `
+				local componentHeading = `{if sortType == BY_COMPONENT_NAME then arrow else ""} Component`
+				local headings = { countHeading, componentHeading }
+				table.insert(items, 1, headings)
 
 				plasma.row({ padding = 30 }, function()
-					local selectedRow = plasma
-						.table(items, {
-							width = 200,
-							headings = true,
-							selectable = true,
-							font = Enum.Font.Code,
-						})
-						:selected()
+					local worldInspectTable = plasma.table(items, {
+						width = 200,
+						headings = true,
+						selectable = true,
+						font = Enum.Font.Code,
+					})
+
+					local selectedHeading = worldInspectTable:selectedHeading()
+
+					if headings[selectedHeading] == headings[1] then
+						if sortType == BY_ENTITY_COUNT then
+							setIsAscendingOrder(not isAscendingOrder)
+						else
+							setSortType(BY_ENTITY_COUNT)
+						end
+					elseif headings[selectedHeading] == headings[2] then
+						if sortType == BY_COMPONENT_NAME then
+							setIsAscendingOrder(not isAscendingOrder)
+						else
+							setSortType(BY_COMPONENT_NAME)
+						end
+					end
+
+					local selectedRow = worldInspectTable:selected()
 
 					if selectedRow then
 						setDebugComponent(selectedRow.component)


### PR DESCRIPTION
## Proposed changes
This change implements sorting in the world inspect table (by entity count `asc-desc` and component name `a-z`). Headers can be clicked once to swap to the desired sort type and then again to change the sort direction. Very useful for Matter worlds with a plethora of entities and components!

## Related issues
Closes #10. 

Many thanks to @memorycode :smile:  for implementing the base functionality for [clickable table headers in Plasma.](https://github.com/matter-ecs/plasma/pull/5.) 

## Preview
[![Image from Gyazo](https://i.gyazo.com/fbe9c12181e5295264fde43d22862ff7.gif)](https://gyazo.com/fbe9c12181e5295264fde43d22862ff7)