### PR TITLE
System search bar

### DIFF
--- a/lib/debugger/debugger.luau
+++ b/lib/debugger/debugger.luau
@@ -25,6 +25,7 @@ local customWidgetConstructors: { [string]: any } = {
 	queryInspect = require(script.Parent.widgets.queryInspect),
 	codeText = require(script.Parent.widgets.codeText),
 	errorInspect = require(script.Parent.widgets.errorInspect),
+	textField = require(script.Parent.widgets.textField),
 }
 
 local IS_SERVER = RunService:IsServer()

--- a/lib/debugger/ui.luau
+++ b/lib/debugger/ui.luau
@@ -2,6 +2,8 @@ local RunService = game:GetService("RunService")
 local World = require(script.Parent.Parent.World)
 local rollingAverage = require(script.Parent.Parent.rollingAverage)
 
+local match, lower = string.match, string.lower
+
 local function systemName(system)
 	local systemFn = if type(system) == "table" then system.system else system
 	local name = debug.info(systemFn, "n")
@@ -124,10 +126,19 @@ local function ui(debugger, loop)
 
 			plasma.space(15)
 			plasma.heading("SYSTEMS")
+
+			local searchFilter = ""
+			if IS_CLIENT then
+				plasma.space(5)
+				local textField = custom.textField("Search...")
+				searchFilter = textField:text()
+				searchFilter = string.gsub(searchFilter, "%s+", "")
+			end
+
 			plasma.space(10)
 
-			local durations = {}
-			local longestDuration = 0
+			local searchResults = {}
+			local noResults = true
 
 			for _, eventName in debugger._eventOrder do
 				local systems = loop._orderedSystemsByEvent[eventName]
@@ -136,65 +147,102 @@ local function ui(debugger, loop)
 					continue
 				end
 
-				plasma.heading(eventName, {
-					font = Enum.Font.Gotham,
-				})
-				plasma.space(5)
-
-				local items = {}
-
 				for _, system in systems do
-					local samples = loop.profiling[system]
-					if samples then
-						local duration = rollingAverage.getAverage(samples)
-						durations[system] = duration
-						longestDuration = math.max(longestDuration, duration)
+					local nameOfSystem = systemName(system)
+					local noMatch = searchFilter ~= "" and not match(lower(nameOfSystem), lower(searchFilter))
+
+					if noMatch then
+						continue
 					end
+
+					if searchResults[eventName] == nil then
+						searchResults[eventName] = {}
+					end
+
+					searchResults[eventName][nameOfSystem] = true
+					noResults = false
 				end
+			end
 
-				for index, system in systems do
-					local averageFrameTime = ""
-					local icon
+			if noResults then
+				plasma.label("No search results")
+			else
+				local durations = {}
+				local longestDuration = 0
 
-					local duration = durations[system] or 0
-					local humanDuration, unit = formatDuration(duration)
-					averageFrameTime = string.format("%.0f%s", humanDuration, unit)
+				for _, eventName in debugger._eventOrder do
+					local systems = loop._orderedSystemsByEvent[eventName]
 
-					if duration > 0.004 then -- 4ms
-						icon = "\xe2\x9a\xa0\xef\xb8\x8f"
+					if not systems or searchResults[eventName] == nil then
+						continue
 					end
 
-					if loop._systemErrors[system] then
-						icon = "\xf0\x9f\x92\xa5"
-					end
-
-					table.insert(items, {
-						text = systemName(system),
-						sideText = averageFrameTime,
-						selected = debugger.debugSystem == system,
-						system = system,
-						icon = icon,
-						barWidth = duration / longestDuration,
-						index = index,
+					plasma.heading(eventName, {
+						font = Enum.Font.Gotham,
 					})
-				end
+					plasma.space(5)
 
-				local selected = custom.selectionList(items):selected()
-				if selected then
-					if selected.system == debugger.debugSystem then
-						debugger.debugSystem = nil
-					else
-						debugger.debugSystem = selected.system
+					local items = {}
+
+					for _, system in systems do
+						local samples = loop.profiling[system]
+						if samples then
+							local duration = rollingAverage.getAverage(samples)
+							durations[system] = duration
+							longestDuration = math.max(longestDuration, duration)
+						end
 					end
-				end
 
-				if debugger.debugSystem then
-					debugger.debugSystemRuntime = durations[debugger.debugSystem]
-				else
-					debugger.debugSystemRuntime = nil
-				end
+					for index, system in systems do
+						local nameOfSystem = systemName(system)
 
-				plasma.space(10)
+						if searchResults[eventName][nameOfSystem] == nil then
+							continue
+						end
+
+						local averageFrameTime = ""
+						local icon
+
+						local duration = durations[system] or 0
+						local humanDuration, unit = formatDuration(duration)
+						averageFrameTime = string.format("%.0f%s", humanDuration, unit)
+
+						if duration > 0.004 then -- 4ms
+							icon = "\xe2\x9a\xa0\xef\xb8\x8f"
+						end
+
+						if loop._systemErrors[system] then
+							icon = "\xf0\x9f\x92\xa5"
+						end
+
+						table.insert(items, {
+							text = nameOfSystem,
+							sideText = averageFrameTime,
+							selected = debugger.debugSystem == system,
+							system = system,
+							icon = icon,
+							barWidth = duration / longestDuration,
+							index = index,
+						})
+					end
+
+					local selected = custom.selectionList(items):selected()
+					if selected then
+						if selected.system == debugger.debugSystem then
+							debugger.debugSystem = nil
+						else
+							debugger.debugSystem = selected.system
+						end
+					end
+
+					if debugger.debugSystem then
+						debugger.debugSystemRuntime = durations[debugger.debugSystem]
+					else
+						debugger.debugSystemRuntime = nil
+					end
+
+					plasma.space(10)
+				end
 			end
 		end)
 

--- a/lib/debugger/widgets/textField.luau
+++ b/lib/debugger/widgets/textField.luau
@@ -1,0 +1,81 @@
+-- temporary TextField component unique to Matter's repository
+-- for the client system search feature
+-- this should be a native Plasma component eventually
+return function(Plasma)
+	local create = Plasma.create
+
+	return Plasma.widget(function(placeholder, options)
+		options = options or { editable = true }
+		local text, setText = Plasma.useState("")
+		local lastUpdate, setLastUpdate = Plasma.useState(os.clock())
+
+		local refs = Plasma.useInstance(function(ref)
+			local style = Plasma.useStyle()
+
+			return create("Frame", {
+				Size = UDim2.new(1, 0, 0, 20),
+				BackgroundTransparency = 1,
+
+				create("UIPadding", {
+					PaddingLeft = UDim.new(0, 1),
+					PaddingRight = UDim.new(0, 1),
+					PaddingTop = UDim.new(0, 0),
+					PaddingBottom = UDim.new(0, 0),
+				}),
+
+				create("TextBox", {
+					[ref] = "textField",
+					AnchorPoint = Vector2.new(0, 0),
+					TextEditable = options.editable,
+					BackgroundTransparency = 0,
+					BackgroundColor3 = style.bg1,
+					Font = Enum.Font.Gotham,
+					TextXAlignment = Enum.TextXAlignment.Left,
+					TextColor3 = style.textColor,
+					TextSize = 12,
+					Size = UDim2.fromScale(1, 1),
+					PlaceholderText = placeholder,
+					Text = text,
+					RichText = true,
+
+					create("UICorner", {
+						CornerRadius = UDim.new(0, 4),
+					}),
+
+					create("UIStroke", {
+						Thickness = 1,
+						ApplyStrokeMode = Enum.ApplyStrokeMode.Border,
+					}),
+
+					create("UIPadding", {
+						PaddingLeft = UDim.new(0, 8),
+						PaddingRight = UDim.new(0, 8),
+						PaddingTop = UDim.new(0, 4),
+						PaddingBottom = UDim.new(0, 4),
+					}),
+
+					Changed = function(property: string)
+						if property == "Text" then
+							setLastUpdate(os.clock())
+						end
+					end,
+				}),
+			})
+		end)
+
+		local instance = refs.textField
+		local shouldUpdate = (os.clock() - lastUpdate) > 0.15
+
+		-- let's cap text updates to every 0.15 seconds
+		if shouldUpdate then
+			setText(instance.Text)
+			setLastUpdate(os.clock())
+		end
+
+		return {
+			text = function()
+				return text
+			end,
+		}
+	end)
+end


### PR DESCRIPTION
## Proposed changes
Adds a search bar to the **client** debugger view. Systems are hidden when they do not match the search filter.

## Related issues
Closes #109 

## Additional comments
The server debugger would also benefit greatly from the search feature but the way that's all setup makes it more complicated. Let's re-visit another time to add the search to the server view.