### PR TITLE
Fix button flashing (remove `row` call)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog][kac], and this project adheres to
 - Removed extra new-lines in component data strings within the debugger entity
   inspect tables.
 - Fixed alt-hover erroring when hovered entity is despawned.
+- Fixed flashing buttons ("View queries" and "View logs") in system inspect panel
 
 ## [0.8.3] - 2024-07-02
 

--- a/lib/debugger/ui.luau
+++ b/lib/debugger/ui.luau
@@ -267,7 +267,7 @@ local function ui(debugger, loop)
 							setQueriesOpen(true)
 						end
 
-						if numLogs == 0 then
+						if numLogs > 0 then
 							if plasma.button(string.format("View logs (%d)", numLogs)):clicked() then
 								setLogsOpen(true)
 							end

--- a/lib/debugger/ui.luau
+++ b/lib/debugger/ui.luau
@@ -263,23 +263,21 @@ local function ui(debugger, loop)
 					}, function()
 						plasma.useKey(name)
 
-						plasma.row(function()
-							if plasma.button(string.format("View queries (%d)", #debugger._queries)):clicked() then
-								setQueriesOpen(true)
-							end
+						if plasma.button(string.format("View queries (%d)", #debugger._queries)):clicked() then
+							setQueriesOpen(true)
+						end
 
-							if numLogs > 0 then
-								if plasma.button(string.format("View logs (%d)", numLogs)):clicked() then
-									setLogsOpen(true)
-								end
+						if numLogs == 0 then
+							if plasma.button(string.format("View logs (%d)", numLogs)):clicked() then
+								setLogsOpen(true)
 							end
-						end)
+						end
 
 						local currentlyDisabled = skipSystems[debugger.debugSystem]
 
 						if
 							plasma
-								.checkbox("Disable system", {
+								.checkbox("<font size='13'>Disable System</font>", {
 									checked = currentlyDisabled,
 								})
 								:clicked()


### PR DESCRIPTION
Fixes button flashing in the system inspect panel (probably casued by Plasma's automatic size implementation).

The buttons are now vertically laid out.

![image](https://github.com/user-attachments/assets/5b5b8836-8e83-4f56-932a-70bfc2a6a03b)
