### PR TITLE
Changed _queryCache to an ordered list

### DIFF
--- a/lib/World.luau
+++ b/lib/World.luau
@@ -74,8 +74,8 @@ function World.new()
 		-- Map of entity ID -> array
 		_entityMetatablesCache = {},
 
-		-- Cache of what query archetypes are compatible with what component archetypes
-		_queryCache = {},
+		-- Cached ordered list of what query archetypes are compatible with what component archetypes
+		_orderedQueryCache = {},
 
 		-- Cache of what entity archetypes have ever existed in the game. This is used for knowing
 		-- when to update the queryCache.
@@ -329,23 +329,23 @@ function World:spawnAt(id, ...)
 end
 
 function World:_newQueryArchetype(queryArchetype)
-	if self._queryCache[queryArchetype] == nil then
-		self._queryCache[queryArchetype] = {}
+	if self._orderedQueryCache[queryArchetype] == nil then
+		self._orderedQueryCache[queryArchetype] = {}
 	else
 		return -- Archetype isn't actually new
 	end
 
 	for entityArchetype in self.storage do
 		if areArchetypesCompatible(queryArchetype, entityArchetype) then
-			self._queryCache[queryArchetype][entityArchetype] = true
+			table.insert(self._orderedQueryCache[queryArchetype], entityArchetype)
 		end
 	end
 end
 
 function World:_updateQueryCache(entityArchetype)
-	for queryArchetype, compatibleArchetypes in pairs(self._queryCache) do
+	for queryArchetype, compatibleArchetypes in pairs(self._orderedQueryCache) do
 		if areArchetypesCompatible(queryArchetype, entityArchetype) then
-			compatibleArchetypes[entityArchetype] = true
+			table.insert(compatibleArchetypes, entityArchetype)
 		end
 	end
 end
@@ -527,7 +527,7 @@ QueryResult.__index = QueryResult
 function QueryResult.new(world, expand, queryArchetype, compatibleArchetypes, metatables)
 	return setmetatable({
 		world = world,
-		currentCompatibleArchetype = next(compatibleArchetypes),
+		currentCompatibleArchetypeIndex = next(compatibleArchetypes),
 		compatibleArchetypes = compatibleArchetypes,
 		storageIndex = 1,
 		metatables = metatables,
@@ -538,8 +538,9 @@ end
 
 local function nextItem(query)
 	local world = query.world
-	local currentCompatibleArchetype = query.currentCompatibleArchetype
 	local compatibleArchetypes = query.compatibleArchetypes
+	local currentCompatibleArchetypeIndex = query.currentCompatibleArchetypeIndex
+	local currentCompatibleArchetype = compatibleArchetypes[currentCompatibleArchetypeIndex]
 
 	local entityId, entityData
 
@@ -550,7 +551,7 @@ local function nextItem(query)
 	end
 
 	while entityId == nil do
-		currentCompatibleArchetype = next(compatibleArchetypes, currentCompatibleArchetype)
+		currentCompatibleArchetypeIndex, currentCompatibleArchetype = next(compatibleArchetypes, currentCompatibleArchetypeIndex)
 
 		if currentCompatibleArchetype == nil then
 			return nil
@@ -563,7 +564,7 @@ local function nextItem(query)
 
 	query.lastEntityId = entityId
 
-	query.currentCompatibleArchetype = currentCompatibleArchetype
+	query.currentCompatibleArchetypeIndex = currentCompatibleArchetypeIndex
 
 	return entityId, entityData
 end
@@ -693,11 +694,11 @@ function QueryResult:without(...)
 
 	local negativeArchetype = `{self._queryArchetype}x{filter}`
 
-	if world._queryCache[negativeArchetype] == nil then
+	if world._orderedQueryCache[negativeArchetype] == nil then
 		world:_newQueryArchetype(negativeArchetype)
 	end
 
-	local compatibleArchetypes = world._queryCache[negativeArchetype]
+	local compatibleArchetypes = world._orderedQueryCache[negativeArchetype]
 
 	self.compatibleArchetypes = compatibleArchetypes
 	self.currentCompatibleArchetype = next(compatibleArchetypes)
@@ -861,11 +862,11 @@ function World:query(...)
 
 	local archetype = archetypeOf(...)
 
-	if self._queryCache[archetype] == nil then
+	if self._orderedQueryCache[archetype] == nil then
 		self:_newQueryArchetype(archetype)
 	end
 
-	local compatibleArchetypes = self._queryCache[archetype]
+	local compatibleArchetypes = self._orderedQueryCache[archetype]
 
 	debug.profileend()
 


### PR DESCRIPTION
## Proposed changes
The compatibleArchetypes list can become out of order for QueryResults. This makes it skip over entirely valid archetype strings. Changing it from a set to a list can resolve this. Because it already uses the set _entityArchetypeCache to add new archetypes to queryCaches, there's no overhead trying to see if a new archetype has already been added to a queryCache or not.

## Related issues
https://discord.com/channels/1234249974959702056/1283058858536992811
(Sorry this isn't a Github Issue, I was expecting to be committing an error myself).

## Additional comments
I initially coded this in the current release, which until this worked without issue in my game. 

The working version uses a different nextItem() function that in general seems to be erroring for my game, even prior to any changes. I also can't replicate the bug in the new release (but I think this could be due in part to the random erroring); however, the new version of nextItem() still relies on next(compatibleArchetypes) as a set, and it is my intention to resolve this bug and not the other things happening with queryResult.

A potential related issue with the new implementation of nextItem() would be around the removal of optimizeQueries / storage levels:
I may just be misreading the way the storage system is now working, but looking at the new implementation, this would likely happen on the entity level instead of the archetype level as entity archetypes change. E.g. an unordered list of entities {[1] = ..., [8] = ..., [95] = ..., [88] = ...} is not guaranteed to be in order.
This can be seen in use in nextItem() because it uses entityId, entityData = next(storage[currentCompatibleArchetype]). If this data is being modified, I would expect an entity to be removed from the currentCompatibleArchetype and moved to another archetype, causing the ordering next returns to sometimes change randomly. 
But this is speculation, and I haven't thoroughly looked into the new storage implementation.