### PR TITLE
Sort systems by duration in Debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog][kac], and this project adheres to
   - The Loop turns deferring on for all worlds given to it.
   - The command buffer is flushed between systems.
   - Iterator invalidation is now only prevented in deferred mode.
+- Added a button to the Debugger's system list to sort by run time.
 
 ### Deprecated
 

--- a/lib/debugger/ui.luau
+++ b/lib/debugger/ui.luau
@@ -140,8 +140,17 @@ local function ui(debugger, loop)
 				end
 			end
 
+			local sortByDuration, setSortByDuration = plasma.useState(false)
+
 			plasma.space(15)
-			plasma.heading("SYSTEMS")
+			plasma.row({ verticalAlignment = Enum.VerticalAlignment.Center }, function()
+				plasma.heading("SYSTEMS")
+
+				if plasma.button(`sort by: {sortByDuration and "duration" or "order"}`):clicked() then
+					setSortByDuration(not sortByDuration)
+				end
+			end)
+
 			plasma.space(10)
 
 			local durations = {}
@@ -210,6 +219,12 @@ local function ui(debugger, loop)
 						barWidth = barWidth,
 						index = index,
 					})
+				end
+
+				if sortByDuration then
+					table.sort(listOfSystems, function(a, b)
+						return (durations[a.system] or 0) > (durations[b.system] or 0)
+					end)
 				end
 
 				local systemList = custom.selectionList(listOfSystems, custom)

--- a/lib/debugger/widgets/selectionList.luau
+++ b/lib/debugger/widgets/selectionList.luau
@@ -127,9 +127,10 @@ return function(Plasma)
 
 		Plasma.useEffect(function()
 			refs.mainText.Text = text
+			refs.index.Text = index or ""
 			refs.button.container.Icon.Text = icon or ""
 			refs.button.container.Icon.Visible = icon ~= nil
-		end, text, icon)
+		end, text, icon, index)
 
 		refs.button.container.sideText.Visible = sideText ~= nil
 		refs.button.container.sideText.Text = if sideText ~= nil then sideText else ""


### PR DESCRIPTION
Added a button to the debugger system list that lets you sort by system run duration.

https://github.com/user-attachments/assets/b2d51acc-69ed-41ad-b96f-5037916dbcfc

