### PR TITLE
Debugger raycast params configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog][kac], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `Debugger.raycastParams` property.
+  - This allows users to customize the `RaycastParams` that is used by the mouse highlight feature. For example, a different CollisionGroup could be specified.
+
 ## [0.9.0-beta.0] - 2024-11-15
 
 ### Added

--- a/lib/debugger/debugger.luau
+++ b/lib/debugger/debugger.luau
@@ -102,6 +102,18 @@ Debugger.__index = Debugger
 ]=]
 
 --[=[
+	@prop raycastParams RaycastParams
+	@within Debugger
+
+	Create this property in Debugger to specify the RaycastParams used for the mouse highlight. For example, you may want to specify a different collision group.
+
+	```lua
+	debugger.raycastParams = RaycastParams.new()
+	raycastParams.CollisionGroup = "SomeGroup"
+	```
+]=]
+
+--[=[
 	@prop componentRefreshFrequency number
 	@within Debugger
 

--- a/lib/debugger/debugger.luau
+++ b/lib/debugger/debugger.luau
@@ -108,8 +108,9 @@ Debugger.__index = Debugger
 	Create this property in Debugger to specify the RaycastParams used for the mouse highlight. For example, you may want to specify a different collision group.
 
 	```lua
-	debugger.raycastParams = RaycastParams.new()
+	local raycastParams = RaycastParams.new()
 	raycastParams.CollisionGroup = "SomeGroup"
+	debugger.raycastParams = raycastParams
 	```
 ]=]
 

--- a/lib/debugger/mouseHighlight.luau
+++ b/lib/debugger/mouseHighlight.luau
@@ -4,7 +4,7 @@ local UserInputService = game:GetService("UserInputService")
 local defaultRaycastParams = RaycastParams.new()
 defaultRaycastParams.IgnoreWater = true
 
-function getInstanceOnMouse(params: RaycastParams?)
+function getInstanceOnMouse(params: RaycastParams)
 	local camera = workspace.CurrentCamera
 	if not camera then
 		return
@@ -13,7 +13,7 @@ function getInstanceOnMouse(params: RaycastParams?)
 	local mouseLocation = UserInputService:GetMouseLocation()
 	local ray = camera:ViewportPointToRay(mouseLocation.X, mouseLocation.Y)
 
-	local result = workspace:Raycast(ray.Origin, ray.Direction * 1000)
+	local result = workspace:Raycast(ray.Origin, ray.Direction * 1000, params)
 	return result and result.Instance
 end
 

--- a/lib/debugger/mouseHighlight.luau
+++ b/lib/debugger/mouseHighlight.luau
@@ -1,7 +1,10 @@
 local RunService = game:GetService("RunService")
 local UserInputService = game:GetService("UserInputService")
 
-function getInstanceOnMouse()
+local defaultRaycastParams = RaycastParams.new()
+defaultRaycastParams.IgnoreWater = true
+
+function getInstanceOnMouse(params: RaycastParams?)
 	local camera = workspace.CurrentCamera
 	if not camera then
 		return
@@ -22,7 +25,7 @@ local function mouseHighlight(debugger, remoteEvent)
 	local lastSent, setLastSent = debugger.plasma.useState()
 
 	if UserInputService:IsKeyDown(Enum.KeyCode.LeftAlt) then
-		local instance = getInstanceOnMouse()
+		local instance = getInstanceOnMouse(debugger.raycastParams or defaultRaycastParams)
 
 		if instance then
 			local id


### PR DESCRIPTION
Allows customizing the RaycastParams used by the Debugger mouse highlight. Also configures default raycast params to ignore terrain water, which is likely not helpful for any users.

Use case:
I have door entities in my game. They are under the "Door" collision group that is not collidable with the "Default" collision group (which, the absence of RaycastParams uses). Therefore, they are not currently selectable with the Matter debugger. By making this change, I can create a "Debug" collision group that is collidable with everything, and set the debugger's collision group accordingly.