### PR TITLE
Fixes QueryChanged for Multiple Worlds

### DIFF
--- a/lib/World.luau
+++ b/lib/World.luau
@@ -128,6 +128,9 @@ function World.new()
 
 		-- Storage for `queryChanged`
 		_changedStorage = {},
+		
+		-- Proxies so `queryChanged` can receive pristine storage in each world in multi-world environments
+		_componentMappings = {},
 	}, World)
 
 	self.rootArchetype = ensureArchetype(self, {})
@@ -520,6 +523,7 @@ function World:clear()
 	self._entityMetatablesCache = {}
 	self._size = 0
 	self._changedStorage = {}
+	self._componentMappings = {}
 end
 
 --[=[
@@ -1195,7 +1199,13 @@ function World:queryChanged(componentToTrack, ...: nil)
 		error("World:queryChanged does not take any additional parameters", 2)
 	end
 
-	local hookState = topoRuntime.useHookState(componentToTrack, cleanupQueryChanged)
+	local componentReference = self._componentMappings[componentToTrack]
+	if not componentReference then
+		componentReference = {}
+		self._componentMappings[componentToTrack] = componentReference
+	end
+	
+	local hookState = topoRuntime.useHookState(componentReference, cleanupQueryChanged)
 
 	if hookState.storage then
 		return function(): any


### PR DESCRIPTION
## Proposed changes

Has queryChanged create a proxy for each component, allowing each world to get its own unique hookState from useHookState

## Related issues

Primarily intended to solve: https://github.com/matter-ecs/matter/issues/155
Has a side-effect of solving: https://github.com/matter-ecs/matter/issues/147 since clearing the proxies will clear the queryChanged storage.

## Additional comments

I had an alternate solution initially where I created the local world storage based on the hookState, but I think that resulted in a far messier solution. https://github.com/TheyCallMeRyan/matter/commit/cb39966f0bba9dee1ffa893ad79e2662c916413b
Both solutions fix both issues though.