### PR TITLE
Fixes world._size bug

### DIFF
--- a/lib/World.luau
+++ b/lib/World.luau
@@ -256,7 +256,10 @@ local function executeDespawn(world: World, despawnCommand: DespawnCommand)
 	table.remove(world.rootArchetype.entities, entityRecord.indexInArchetype)
 	world.allEntities[entityId] = nil
 
-	world._size -= 1
+	local willBeDeleted = world.markedForDeletion[entityId] ~= nil
+	if willBeDeleted then
+		world._size -= 1
+	end
 end
 
 local function executeInsert(world: World, insertCommand: InsertCommand)


### PR DESCRIPTION
## Proposed changes

This change makes the executeDespawn work in conjunction with the markedForDeletion in spawnAt so the size is always correct.

## Related issues

See: https://github.com/matter-ecs/matter/issues/158

## Additional comments
