### PR TITLE
Remove dev dependencies from wally index

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -25,6 +25,3 @@ exclude = [
     "matter.rbxm",
     "roblox.toml",
 ]
-
-[dev-dependencies]
-TestEZ = "roblox/testez@0.4.1"


### PR DESCRIPTION
I was unable to import matter-ecs/matter@0.8.5 due to it depending on dev dependencies as a non-dev dependency.

(I'm an idiot, don't trust me completely)